### PR TITLE
Add option to generate PAS clusters per sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.snakemake/
+bulk_polya_reads/

--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,10 @@ count_per_sample: False
 # currently, one of vlasenok,two_class_simple,vlasenok_two_class
 pas_filter_method: "two_class_simple"
 
+# Whether to also cluster valid PATRs per-sample prior to specified pooling method
+# Default = False
+cluster_per_sample: True
+
 # Length of interval to extend either side of provided PAS coordinates to cluster polyA junction reads 
 # (note that polyA site coordinates will be 1nt long, so total max length of cluster = 2*window + 1)
 # default: 12


### PR DESCRIPTION
Adds an extra optional rule to re-run the PATR filtering and clustering for each sample. Toggled with a parameter in the config file. 

Successful run with local test data (to be added to the repo) [2025-01-19T174548.568500.snakemake.log](https://github.com/user-attachments/files/18469799/2025-01-19T174548.568500.snakemake.log)

Also adds a minimal gitignore file
